### PR TITLE
OPS-0 Add missing tags to security group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CURRENT_DIR     = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 TF_EXAMPLES     = $(sort $(dir $(wildcard $(CURRENT_DIR)examples/*/)))
 TF_MODULES      = $(sort $(dir $(wildcard $(CURRENT_DIR)modules/*/)))
 
-TF_VERSION      = 0.12.2
+TF_VERSION      = light
 TF_DOCS_VERSION = 0.6.0
 
 # Adjust your delimiter here or overwrite via make arguments

--- a/rds.tf
+++ b/rds.tf
@@ -26,6 +26,8 @@ module "rds_sg" {
 
   ingress_cidr_blocks = var.rds_allowed_subnet_cidrs
   ingress_rules       = [lookup(local.rds_sg_rule_name, var.rds_engine, "postgresql-tcp")]
+
+  tags = var.tags
 }
 
 # Random password generator


### PR DESCRIPTION
# Add missing tags to security group

Currently the specified tags are not passed on to the security group module. This PR fixes that.


Upcoming git tag will be: `v2.0.1`