### PR TITLE
rds_dbname_override

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,12 +243,13 @@ The following resources _CAN_ be created:
 | rds\_backup\_retention\_period | Retention period for DB snapshots in days | string | `"14"` | no |
 | rds\_backup\_window | Backup window | string | `"03:00-06:00"` | no |
 | rds\_db\_subnet\_group\_name | Subnet groups for RDS instance | string | `""` | no |
+| rds\_dbname\_override | RDS DB Name override in case the identifier is not wished as db name | string | `""` | no |
 | rds\_deletion\_protection | Protect RDS instance from deletion | string | `"true"` | no |
 | rds\_enabled | Set to false to prevent the module from creating any rds resources | string | `"false"` | no |
 | rds\_engine | RDS instance engine | string | `"mysql"` | no |
 | rds\_engine\_version | RDS instance engine version | string | `"5.7.19"` | no |
 | rds\_family | Parameter Group | string | `"mysql5.7"` | no |
-| rds\_identifier\_override | Redis cluster ID. Use only lowercase, numbers and -, _., only use when it needs to be different from var.name | string | `""` | no |
+| rds\_identifier\_override | RDS identifier override. Use only lowercase, numbers and -, _., only use when it needs to be different from var.name | string | `""` | no |
 | rds\_kms\_key\_id | KMS key ARN for storage encryption | string | `""` | no |
 | rds\_maintenance\_window | Window of RDS Maintenance | string | `"Mon:16:00-Mon:18:00"` | no |
 | rds\_major\_engine\_version | RDS instance major engine version | string | `"5.7"` | no |

--- a/examples/dynamodb/README.md
+++ b/examples/dynamodb/README.md
@@ -30,12 +30,13 @@
 | rds\_backup\_retention\_period | Retention period for DB snapshots in days | string | `"14"` | no |
 | rds\_backup\_window | Backup window | string | `"03:00-06:00"` | no |
 | rds\_db\_subnet\_group\_name | Subnet groups for RDS instance | string | `""` | no |
+| rds\_dbname\_override | RDS DB Name override in case the identifier is not wished as db name | string | `""` | no |
 | rds\_deletion\_protection | Protect RDS instance from deletion | string | `"true"` | no |
 | rds\_enabled | Set to false to prevent the module from creating any rds resources | string | `"false"` | no |
 | rds\_engine | RDS instance engine | string | `"mysql"` | no |
 | rds\_engine\_version | RDS instance engine version | string | `"5.7.19"` | no |
 | rds\_family | Parameter Group | string | `"mysql5.7"` | no |
-| rds\_identifier\_override | Redis cluster ID. Use only lowercase, numbers and -, _., only use when it needs to be different from var.name | string | `""` | no |
+| rds\_identifier\_override | RDS identifier override. Use only lowercase, numbers and -, _., only use when it needs to be different from var.name | string | `""` | no |
 | rds\_kms\_key\_id | KMS key ARN for storage encryption | string | `""` | no |
 | rds\_maintenance\_window | Window of RDS Maintenance | string | `"Mon:16:00-Mon:18:00"` | no |
 | rds\_major\_engine\_version | RDS instance major engine version | string | `"5.7"` | no |

--- a/examples/iam/README.md
+++ b/examples/iam/README.md
@@ -30,12 +30,13 @@
 | rds\_backup\_retention\_period | Retention period for DB snapshots in days | string | `"14"` | no |
 | rds\_backup\_window | Backup window | string | `"03:00-06:00"` | no |
 | rds\_db\_subnet\_group\_name | Subnet groups for RDS instance | string | `""` | no |
+| rds\_dbname\_override | RDS DB Name override in case the identifier is not wished as db name | string | `""` | no |
 | rds\_deletion\_protection | Protect RDS instance from deletion | string | `"true"` | no |
 | rds\_enabled | Set to false to prevent the module from creating any rds resources | string | `"false"` | no |
 | rds\_engine | RDS instance engine | string | `"mysql"` | no |
 | rds\_engine\_version | RDS instance engine version | string | `"5.7.19"` | no |
 | rds\_family | Parameter Group | string | `"mysql5.7"` | no |
-| rds\_identifier\_override | Redis cluster ID. Use only lowercase, numbers and -, _., only use when it needs to be different from var.name | string | `""` | no |
+| rds\_identifier\_override | RDS identifier override. Use only lowercase, numbers and -, _., only use when it needs to be different from var.name | string | `""` | no |
 | rds\_kms\_key\_id | KMS key ARN for storage encryption | string | `""` | no |
 | rds\_maintenance\_window | Window of RDS Maintenance | string | `"Mon:16:00-Mon:18:00"` | no |
 | rds\_major\_engine\_version | RDS instance major engine version | string | `"5.7"` | no |

--- a/examples/rds/README.md
+++ b/examples/rds/README.md
@@ -30,12 +30,13 @@
 | rds\_backup\_retention\_period | Retention period for DB snapshots in days | string | `"14"` | no |
 | rds\_backup\_window | Backup window | string | `"03:00-06:00"` | no |
 | rds\_db\_subnet\_group\_name | Subnet groups for RDS instance | string | `""` | no |
+| rds\_dbname\_override | RDS DB Name override in case the identifier is not wished as db name | string | `""` | no |
 | rds\_deletion\_protection | Protect RDS instance from deletion | string | `"true"` | no |
 | rds\_enabled | Set to false to prevent the module from creating any rds resources | string | `"false"` | no |
 | rds\_engine | RDS instance engine | string | `"mysql"` | no |
 | rds\_engine\_version | RDS instance engine version | string | `"5.7.19"` | no |
 | rds\_family | Parameter Group | string | `"mysql5.7"` | no |
-| rds\_identifier\_override | Redis cluster ID. Use only lowercase, numbers and -, _., only use when it needs to be different from var.name | string | `""` | no |
+| rds\_identifier\_override | RDS identifier override. Use only lowercase, numbers and -, _., only use when it needs to be different from var.name | string | `""` | no |
 | rds\_kms\_key\_id | KMS key ARN for storage encryption | string | `""` | no |
 | rds\_maintenance\_window | Window of RDS Maintenance | string | `"Mon:16:00-Mon:18:00"` | no |
 | rds\_major\_engine\_version | RDS instance major engine version | string | `"5.7"` | no |

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -30,12 +30,13 @@
 | rds\_backup\_retention\_period | Retention period for DB snapshots in days | string | `"14"` | no |
 | rds\_backup\_window | Backup window | string | `"03:00-06:00"` | no |
 | rds\_db\_subnet\_group\_name | Subnet groups for RDS instance | string | `""` | no |
+| rds\_dbname\_override | RDS DB Name override in case the identifier is not wished as db name | string | `""` | no |
 | rds\_deletion\_protection | Protect RDS instance from deletion | string | `"true"` | no |
 | rds\_enabled | Set to false to prevent the module from creating any rds resources | string | `"false"` | no |
 | rds\_engine | RDS instance engine | string | `"mysql"` | no |
 | rds\_engine\_version | RDS instance engine version | string | `"5.7.19"` | no |
 | rds\_family | Parameter Group | string | `"mysql5.7"` | no |
-| rds\_identifier\_override | Redis cluster ID. Use only lowercase, numbers and -, _., only use when it needs to be different from var.name | string | `""` | no |
+| rds\_identifier\_override | RDS identifier override. Use only lowercase, numbers and -, _., only use when it needs to be different from var.name | string | `""` | no |
 | rds\_kms\_key\_id | KMS key ARN for storage encryption | string | `""` | no |
 | rds\_maintenance\_window | Window of RDS Maintenance | string | `"Mon:16:00-Mon:18:00"` | no |
 | rds\_major\_engine\_version | RDS instance major engine version | string | `"5.7"` | no |

--- a/rds.tf
+++ b/rds.tf
@@ -1,5 +1,6 @@
 locals {
   rds_identifier = length(var.rds_identifier_override) > 0 ? var.rds_identifier_override : var.name
+  rds_db_name    = length(var.rds_dbname_override) > 0 ? var.rds_dbname_override : local.rds_identifier
   password       = var.rds_use_random_password ? join("", random_string.password.*.result) : var.rds_admin_pass
 }
 
@@ -64,7 +65,7 @@ module "rds" {
   allocated_storage    = var.rds_allocated_storage
   family               = var.rds_family
 
-  name     = local.rds_identifier
+  name     = local.rds_db_name
   username = var.rds_admin_user
   password = local.password
   port     = var.rds_port

--- a/variables.tf
+++ b/variables.tf
@@ -202,7 +202,12 @@ variable "rds_enabled" {
 }
 
 variable "rds_identifier_override" {
-  description = "Redis cluster ID. Use only lowercase, numbers and -, _., only use when it needs to be different from var.name"
+  description = "RDS identifier override. Use only lowercase, numbers and -, _., only use when it needs to be different from var.name"
+  default     = ""
+}
+
+variable "rds_dbname_override" {
+  description = "RDS DB Name override in case the identifier is not wished as db name"
   default     = ""
 }
 


### PR DESCRIPTION
## What

Adding an override variable for the db name.

## Why

In some cases it can be wishful that the identifier should not be taken for the db name.