### PR TITLE
Feat/dynamodb 2nd table

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,11 +225,19 @@ The following resources _CAN_ be created:
 | aws\_route53\_zone\_endpoints\_enabled | To enable the lookup of the domain used for RDS/Redis private endpoint | string | `"false"` | no |
 | aws\_route53\_zone\_private\_endpoint\_enabled | To enable the lookup of the domain used for RDS/Redis private endpoint, we need to set this to true | string | `"true"` | no |
 | aws\_route53\_zone\_public\_endpoint\_enabled | To enable the lookup of the domain used for RDS/Redis public endpoint, we need to set this to true | string | `"true"` | no |
+| dynamodb2\_attributes | Additional DynamoDB attributes in the form of a list of mapped values | list | `[]` | no |
+| dynamodb2\_enabled | Set to false to prevent the module from creating any dynamodb resources | string | `"false"` | no |
+| dynamodb2\_global\_secondary\_index\_map | Additional global secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
+| dynamodb2\_hash\_key | DynamoDB table Hash Key | string | `""` | no |
+| dynamodb2\_local\_secondary\_index\_map | Additional local secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
+| dynamodb2\_name\_override | define dynamodb2_name_override to set a name differnt from var.name | string | `""` | no |
+| dynamodb2\_range\_key | DynamoDB table Range Key | string | `""` | no |
 | dynamodb\_attributes | Additional DynamoDB attributes in the form of a list of mapped values | list | `[]` | no |
 | dynamodb\_enabled | Set to false to prevent the module from creating any dynamodb resources | string | `"false"` | no |
 | dynamodb\_global\_secondary\_index\_map | Additional global secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
 | dynamodb\_hash\_key | DynamoDB table Hash Key | string | `""` | no |
 | dynamodb\_local\_secondary\_index\_map | Additional local secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
+| dynamodb\_name\_override | define dynamodb_name_override to set a name differnt from var.name | string | `""` | no |
 | dynamodb\_range\_key | DynamoDB table Range Key | string | `""` | no |
 | endpoints\_domain | The domain / route53 zone we need to add a record with | string | `""` | no |
 | iam\_role\_enabled | Set to false to prevent iam role creation | string | `"false"` | no |
@@ -284,6 +292,13 @@ The following resources _CAN_ be created:
 
 | Name | Description |
 |------|-------------|
+| dynamodb2\_global\_secondary\_index\_names | DynamoDB secondary index names |
+| dynamodb2\_local\_secondary\_index\_names | DynamoDB local index names |
+| dynamodb2\_table\_arn | DynamoDB table ARN |
+| dynamodb2\_table\_id | DynamoDB table ID |
+| dynamodb2\_table\_name | DynamoDB table name |
+| dynamodb2\_table\_stream\_arn | DynamoDB table stream ARN |
+| dynamodb2\_table\_stream\_label | DynamoDB table stream label |
 | dynamodb\_global\_secondary\_index\_names | DynamoDB secondary index names |
 | dynamodb\_local\_secondary\_index\_names | DynamoDB local index names |
 | dynamodb\_table\_arn | DynamoDB table ARN |

--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -1,3 +1,7 @@
+locals {
+  dynamodb_name = length(var.dynamodb_name_override) > 0 ? var.dynamodb_name_override : var.name
+}
+
 resource "null_resource" "dynamodb_checker" {
   provisioner "local-exec" {
     command = "echo 'Condition failed. Expected: DynamoDB enabled, but hash_key not set' && exit 1"
@@ -11,7 +15,7 @@ module "dynamodb" {
 
   namespace = ""
   stage     = ""
-  name      = var.name
+  name      = local.dynamodb_name_override
   hash_key  = var.dynamodb_hash_key
   range_key = var.dynamodb_range_key
   enabled   = var.dynamodb_enabled ? "true" : "false"

--- a/dynamodb_2.tf
+++ b/dynamodb_2.tf
@@ -1,0 +1,32 @@
+locals {
+  dynamodb2_name = length(var.dynamodb2_name_override) > 0 ? var.dynamodb2_name_override : var.name
+}
+
+
+resource "null_resource" "dynamodb2_checker" {
+  provisioner "local-exec" {
+    command = "echo 'Condition failed. Expected: DynamoDB enabled, but hash_key not set' && exit 1"
+  }
+
+  count = var.dynamodb2_enabled && length(var.dynamodb2_hash_key) < 1 ? 1 : 0
+}
+
+module "dynamodb2" {
+  source = "git::https://github.com/Flaconi/terraform-aws-dynamodb.git?ref=v0.12.0"
+
+  namespace = ""
+  stage     = ""
+  name      = local.dynamodb2_name
+  hash_key  = var.dynamodb2_hash_key
+  range_key = var.dynamodb2_range_key
+  enabled   = var.dynamodb2_enabled ? "true" : "false"
+
+  dynamodb2_attributes       = var.dynamodb2_attributes
+  global_secondary_index_map = var.dynamodb2_global_secondary_index_map
+  local_secondary_index_map  = var.dynamodb2_local_secondary_index_map
+
+  # We can always extend the defaults and add them
+  enable_autoscaler = false
+
+  tags = local.tags
+}

--- a/examples/dynamodb/README.md
+++ b/examples/dynamodb/README.md
@@ -12,11 +12,19 @@
 | aws\_route53\_zone\_endpoints\_enabled | To enable the lookup of the domain used for RDS/Redis private endpoint | string | `"false"` | no |
 | aws\_route53\_zone\_private\_endpoint\_enabled | To enable the lookup of the domain used for RDS/Redis private endpoint, we need to set this to true | string | `"true"` | no |
 | aws\_route53\_zone\_public\_endpoint\_enabled | To enable the lookup of the domain used for RDS/Redis public endpoint, we need to set this to true | string | `"true"` | no |
+| dynamodb2\_attributes | Additional DynamoDB attributes in the form of a list of mapped values | list | `[]` | no |
+| dynamodb2\_enabled | Set to false to prevent the module from creating any dynamodb resources | string | `"false"` | no |
+| dynamodb2\_global\_secondary\_index\_map | Additional global secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
+| dynamodb2\_hash\_key | DynamoDB table Hash Key | string | `""` | no |
+| dynamodb2\_local\_secondary\_index\_map | Additional local secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
+| dynamodb2\_name\_override | define dynamodb2_name_override to set a name differnt from var.name | string | `""` | no |
+| dynamodb2\_range\_key | DynamoDB table Range Key | string | `""` | no |
 | dynamodb\_attributes | Additional DynamoDB attributes in the form of a list of mapped values | list | `[]` | no |
 | dynamodb\_enabled | Set to false to prevent the module from creating any dynamodb resources | string | `"false"` | no |
 | dynamodb\_global\_secondary\_index\_map | Additional global secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
 | dynamodb\_hash\_key | DynamoDB table Hash Key | string | `""` | no |
 | dynamodb\_local\_secondary\_index\_map | Additional local secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
+| dynamodb\_name\_override | define dynamodb_name_override to set a name differnt from var.name | string | `""` | no |
 | dynamodb\_range\_key | DynamoDB table Range Key | string | `""` | no |
 | endpoints\_domain | The domain / route53 zone we need to add a record with | string | `""` | no |
 | iam\_role\_enabled | Set to false to prevent iam role creation | string | `"false"` | no |
@@ -71,6 +79,13 @@
 
 | Name | Description |
 |------|-------------|
+| dynamodb2\_global\_secondary\_index\_names | DynamoDB secondary index names |
+| dynamodb2\_local\_secondary\_index\_names | DynamoDB local index names |
+| dynamodb2\_table\_arn | DynamoDB table ARN |
+| dynamodb2\_table\_id | DynamoDB table ID |
+| dynamodb2\_table\_name | DynamoDB table name |
+| dynamodb2\_table\_stream\_arn | DynamoDB table stream ARN |
+| dynamodb2\_table\_stream\_label | DynamoDB table stream label |
 | dynamodb\_global\_secondary\_index\_names | DynamoDB secondary index names |
 | dynamodb\_local\_secondary\_index\_names | DynamoDB local index names |
 | dynamodb\_table\_arn | DynamoDB table ARN |

--- a/examples/iam/README.md
+++ b/examples/iam/README.md
@@ -12,11 +12,19 @@
 | aws\_route53\_zone\_endpoints\_enabled | To enable the lookup of the domain used for RDS/Redis private endpoint | string | `"false"` | no |
 | aws\_route53\_zone\_private\_endpoint\_enabled | To enable the lookup of the domain used for RDS/Redis private endpoint, we need to set this to true | string | `"true"` | no |
 | aws\_route53\_zone\_public\_endpoint\_enabled | To enable the lookup of the domain used for RDS/Redis public endpoint, we need to set this to true | string | `"true"` | no |
+| dynamodb2\_attributes | Additional DynamoDB attributes in the form of a list of mapped values | list | `[]` | no |
+| dynamodb2\_enabled | Set to false to prevent the module from creating any dynamodb resources | string | `"false"` | no |
+| dynamodb2\_global\_secondary\_index\_map | Additional global secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
+| dynamodb2\_hash\_key | DynamoDB table Hash Key | string | `""` | no |
+| dynamodb2\_local\_secondary\_index\_map | Additional local secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
+| dynamodb2\_name\_override | define dynamodb2_name_override to set a name differnt from var.name | string | `""` | no |
+| dynamodb2\_range\_key | DynamoDB table Range Key | string | `""` | no |
 | dynamodb\_attributes | Additional DynamoDB attributes in the form of a list of mapped values | list | `[]` | no |
 | dynamodb\_enabled | Set to false to prevent the module from creating any dynamodb resources | string | `"false"` | no |
 | dynamodb\_global\_secondary\_index\_map | Additional global secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
 | dynamodb\_hash\_key | DynamoDB table Hash Key | string | `""` | no |
 | dynamodb\_local\_secondary\_index\_map | Additional local secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
+| dynamodb\_name\_override | define dynamodb_name_override to set a name differnt from var.name | string | `""` | no |
 | dynamodb\_range\_key | DynamoDB table Range Key | string | `""` | no |
 | endpoints\_domain | The domain / route53 zone we need to add a record with | string | `""` | no |
 | iam\_role\_enabled | Set to false to prevent iam role creation | string | `"false"` | no |
@@ -71,6 +79,13 @@
 
 | Name | Description |
 |------|-------------|
+| dynamodb2\_global\_secondary\_index\_names | DynamoDB secondary index names |
+| dynamodb2\_local\_secondary\_index\_names | DynamoDB local index names |
+| dynamodb2\_table\_arn | DynamoDB table ARN |
+| dynamodb2\_table\_id | DynamoDB table ID |
+| dynamodb2\_table\_name | DynamoDB table name |
+| dynamodb2\_table\_stream\_arn | DynamoDB table stream ARN |
+| dynamodb2\_table\_stream\_label | DynamoDB table stream label |
 | dynamodb\_global\_secondary\_index\_names | DynamoDB secondary index names |
 | dynamodb\_local\_secondary\_index\_names | DynamoDB local index names |
 | dynamodb\_table\_arn | DynamoDB table ARN |

--- a/examples/rds/README.md
+++ b/examples/rds/README.md
@@ -12,11 +12,19 @@
 | aws\_route53\_zone\_endpoints\_enabled | To enable the lookup of the domain used for RDS/Redis private endpoint | string | `"false"` | no |
 | aws\_route53\_zone\_private\_endpoint\_enabled | To enable the lookup of the domain used for RDS/Redis private endpoint, we need to set this to true | string | `"true"` | no |
 | aws\_route53\_zone\_public\_endpoint\_enabled | To enable the lookup of the domain used for RDS/Redis public endpoint, we need to set this to true | string | `"true"` | no |
+| dynamodb2\_attributes | Additional DynamoDB attributes in the form of a list of mapped values | list | `[]` | no |
+| dynamodb2\_enabled | Set to false to prevent the module from creating any dynamodb resources | string | `"false"` | no |
+| dynamodb2\_global\_secondary\_index\_map | Additional global secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
+| dynamodb2\_hash\_key | DynamoDB table Hash Key | string | `""` | no |
+| dynamodb2\_local\_secondary\_index\_map | Additional local secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
+| dynamodb2\_name\_override | define dynamodb2_name_override to set a name differnt from var.name | string | `""` | no |
+| dynamodb2\_range\_key | DynamoDB table Range Key | string | `""` | no |
 | dynamodb\_attributes | Additional DynamoDB attributes in the form of a list of mapped values | list | `[]` | no |
 | dynamodb\_enabled | Set to false to prevent the module from creating any dynamodb resources | string | `"false"` | no |
 | dynamodb\_global\_secondary\_index\_map | Additional global secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
 | dynamodb\_hash\_key | DynamoDB table Hash Key | string | `""` | no |
 | dynamodb\_local\_secondary\_index\_map | Additional local secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
+| dynamodb\_name\_override | define dynamodb_name_override to set a name differnt from var.name | string | `""` | no |
 | dynamodb\_range\_key | DynamoDB table Range Key | string | `""` | no |
 | endpoints\_domain | The domain / route53 zone we need to add a record with | string | `""` | no |
 | iam\_role\_enabled | Set to false to prevent iam role creation | string | `"false"` | no |
@@ -71,6 +79,13 @@
 
 | Name | Description |
 |------|-------------|
+| dynamodb2\_global\_secondary\_index\_names | DynamoDB secondary index names |
+| dynamodb2\_local\_secondary\_index\_names | DynamoDB local index names |
+| dynamodb2\_table\_arn | DynamoDB table ARN |
+| dynamodb2\_table\_id | DynamoDB table ID |
+| dynamodb2\_table\_name | DynamoDB table name |
+| dynamodb2\_table\_stream\_arn | DynamoDB table stream ARN |
+| dynamodb2\_table\_stream\_label | DynamoDB table stream label |
 | dynamodb\_global\_secondary\_index\_names | DynamoDB secondary index names |
 | dynamodb\_local\_secondary\_index\_names | DynamoDB local index names |
 | dynamodb\_table\_arn | DynamoDB table ARN |

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -12,11 +12,19 @@
 | aws\_route53\_zone\_endpoints\_enabled | To enable the lookup of the domain used for RDS/Redis private endpoint | string | `"false"` | no |
 | aws\_route53\_zone\_private\_endpoint\_enabled | To enable the lookup of the domain used for RDS/Redis private endpoint, we need to set this to true | string | `"true"` | no |
 | aws\_route53\_zone\_public\_endpoint\_enabled | To enable the lookup of the domain used for RDS/Redis public endpoint, we need to set this to true | string | `"true"` | no |
+| dynamodb2\_attributes | Additional DynamoDB attributes in the form of a list of mapped values | list | `[]` | no |
+| dynamodb2\_enabled | Set to false to prevent the module from creating any dynamodb resources | string | `"false"` | no |
+| dynamodb2\_global\_secondary\_index\_map | Additional global secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
+| dynamodb2\_hash\_key | DynamoDB table Hash Key | string | `""` | no |
+| dynamodb2\_local\_secondary\_index\_map | Additional local secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
+| dynamodb2\_name\_override | define dynamodb2_name_override to set a name differnt from var.name | string | `""` | no |
+| dynamodb2\_range\_key | DynamoDB table Range Key | string | `""` | no |
 | dynamodb\_attributes | Additional DynamoDB attributes in the form of a list of mapped values | list | `[]` | no |
 | dynamodb\_enabled | Set to false to prevent the module from creating any dynamodb resources | string | `"false"` | no |
 | dynamodb\_global\_secondary\_index\_map | Additional global secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
 | dynamodb\_hash\_key | DynamoDB table Hash Key | string | `""` | no |
 | dynamodb\_local\_secondary\_index\_map | Additional local secondary indexes in the form of a list of mapped values | list(string) | `[]` | no |
+| dynamodb\_name\_override | define dynamodb_name_override to set a name differnt from var.name | string | `""` | no |
 | dynamodb\_range\_key | DynamoDB table Range Key | string | `""` | no |
 | endpoints\_domain | The domain / route53 zone we need to add a record with | string | `""` | no |
 | iam\_role\_enabled | Set to false to prevent iam role creation | string | `"false"` | no |
@@ -71,6 +79,13 @@
 
 | Name | Description |
 |------|-------------|
+| dynamodb2\_global\_secondary\_index\_names | DynamoDB secondary index names |
+| dynamodb2\_local\_secondary\_index\_names | DynamoDB local index names |
+| dynamodb2\_table\_arn | DynamoDB table ARN |
+| dynamodb2\_table\_id | DynamoDB table ID |
+| dynamodb2\_table\_name | DynamoDB table name |
+| dynamodb2\_table\_stream\_arn | DynamoDB table stream ARN |
+| dynamodb2\_table\_stream\_label | DynamoDB table stream label |
 | dynamodb\_global\_secondary\_index\_names | DynamoDB secondary index names |
 | dynamodb\_local\_secondary\_index\_names | DynamoDB local index names |
 | dynamodb\_table\_arn | DynamoDB table ARN |

--- a/iam.tf
+++ b/iam.tf
@@ -130,3 +130,57 @@ resource "aws_iam_role_policy" "dynamodb_role_policy" {
   # This defines what permissions our role will be given
   policy = data.aws_iam_policy_document.dynamodb_full_access[0].json
 }
+
+data "aws_iam_policy_document" "dynamodb2_full_access" {
+  count = var.dynamodb2_enabled && var.iam_role_enabled ? 1 : 0
+
+  statement {
+    sid    = "ListDynamoDB"
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:dynamodb:*:*:table/${module.dynamodb2.table_id}",
+    ]
+
+    actions = [
+      "dynamodb:List*",
+      "dynamodb:DescribeReservedCapacity*",
+      "dynamodb:DescribeLimits",
+      "dynamodb:DescribeTimeToLive",
+    ]
+  }
+
+  statement {
+    sid    = "FullAccess"
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:dynamodb:*:*:table/${module.dynamodb2.table_id}",
+      "arn:aws:dynamodb:*:*:table/${module.dynamodb2.table_id}/*",
+    ]
+
+    actions = [
+      "dynamodb:BatchGet*",
+      "dynamodb:DescribeStream",
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:BatchWrite*",
+      "dynamodb:CreateTable",
+      "dynamodb:DeleteItem",
+      "dynamodb:Update*",
+      "dynamodb:PutItem",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "dynamodb_role_policy" {
+  count = var.dynamodb2_enabled && var.iam_role_enabled ? 1 : 0
+  role  = element(concat(aws_iam_role.this.*.name, [""]), 0)
+
+  name = "dynamodb2-policy"
+
+  # This defines what permissions our role will be given
+  policy = data.aws_iam_policy_document.dynamodb2_full_access[0].json
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -74,6 +74,45 @@ output "dynamodb_table_stream_label" {
 }
 
 # -------------------------------------------------------------------------------------------------
+# DynamoDB 2
+# -------------------------------------------------------------------------------------------------
+output "dynamodb2_table_name" {
+  description = "DynamoDB table name"
+  value       = module.dynamodb2.table_name
+}
+
+output "dynamodb2_table_id" {
+  description = "DynamoDB table ID"
+  value       = module.dynamodb2.table_id
+}
+
+output "dynamodb2_table_arn" {
+  description = "DynamoDB table ARN"
+  value       = module.dynamodb2.table_arn
+}
+
+output "dynamodb2_global_secondary_index_names" {
+  description = "DynamoDB secondary index names"
+  value       = [module.dynamodb2.global_secondary_index_names]
+}
+
+output "dynamodb2_local_secondary_index_names" {
+  description = "DynamoDB local index names"
+  value       = [module.dynamodb2.local_secondary_index_names]
+}
+
+output "dynamodb2_table_stream_arn" {
+  description = "DynamoDB table stream ARN"
+  value       = module.dynamodb2.table_stream_arn
+}
+
+output "dynamodb2_table_stream_label" {
+  description = "DynamoDB table stream label"
+  value       = module.dynamodb2.table_stream_label
+}
+
+
+# -------------------------------------------------------------------------------------------------
 # Redis
 # -------------------------------------------------------------------------------------------------
 output "this_redis_subnet_group_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,11 @@ variable "dynamodb_enabled" {
   default     = false
 }
 
+variable "dynamodb_name_override" {
+  description = "define dynamodb_name_override to set a name differnt from var.name "
+  default     = ""
+}
+
 variable "dynamodb_hash_key" {
   description = "DynamoDB table Hash Key"
   type        = string
@@ -113,6 +118,49 @@ variable "dynamodb_local_secondary_index_map" {
   type        = list(string)
   default     = []
 }
+# -------------------------------------------------------------------------------------------------
+# DynamoDB 2 Allows for a second table in Dynamodb
+# -------------------------------------------------------------------------------------------------
+
+variable "dynamodb2_enabled" {
+  description = "Set to false to prevent the module from creating any dynamodb resources"
+  default     = false
+}
+
+variable "dynamodb2_name_override" {
+  description = "define dynamodb2_name_override to set a name differnt from var.name"
+  default     = ""
+}
+
+variable "dynamodb2_hash_key" {
+  description = "DynamoDB table Hash Key"
+  type        = string
+  default     = ""
+}
+
+variable "dynamodb2_range_key" {
+  description = "DynamoDB table Range Key"
+  type        = string
+  default     = ""
+}
+
+variable "dynamodb2_attributes" {
+  description = "Additional DynamoDB attributes in the form of a list of mapped values"
+  default     = []
+}
+
+variable "dynamodb2_global_secondary_index_map" {
+  description = "Additional global secondary indexes in the form of a list of mapped values"
+  type        = list(string)
+  default     = []
+}
+
+variable "dynamodb2_local_secondary_index_map" {
+  description = "Additional local secondary indexes in the form of a list of mapped values"
+  type        = list(string)
+  default     = []
+}
+
 
 # -------------------------------------------------------------------------------------------------
 # Redis


### PR DESCRIPTION
## What

Addressing the need to create a 2nd dynamodb table with this module.

## Why

Microservice can have more than 1 dynamodb table, currently there is no pretty way to catch this hence duplicated code I've added this way.