### PR TITLE
OPS-0 Use DynamoDB module from TF registry

### DIFF
--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -7,7 +7,8 @@ resource "null_resource" "dynamodb_checker" {
 }
 
 module "dynamodb" {
-  source = "git::https://github.com/Flaconi/terraform-aws-dynamodb.git?ref=v0.12.0"
+  source  = "Flaconi/dynamodb/aws"
+  version = "0.12.0"
 
   namespace = ""
   stage     = ""


### PR DESCRIPTION
In order to use dependabot, all module must come from Terraform module registry. This PR addresses this issue.