### PR TITLE
set lifecycle_rule 'enabled' to true by default, no need to pass it as parameter

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -42,7 +42,7 @@ resource "aws_s3_bucket" "this" {
 
     content {
       id      = rule.value.id
-      enabled = rule.value.enabled
+      enabled = lookup(rule.value, "enabled", true)
       prefix  = rule.value.prefix
       expiration {
         days = rule.value.expiration_days


### PR DESCRIPTION
Every lifecycle-rule has an enabled flag we currently have to pass as parameter, this feels redundant. This change sets the enabled flag to true by default