### PR TITLE
OPS-3896

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CURRENT_DIR     = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 TF_EXAMPLES     = $(sort $(dir $(wildcard $(CURRENT_DIR)examples/*/)))
 TF_MODULES      = $(sort $(dir $(wildcard $(CURRENT_DIR)modules/*/)))
 
-TF_VERSION      = light
+TF_VERSION      = 0.12.29
 TF_DOCS_VERSION = 0.6.0
 
 # Adjust your delimiter here or overwrite via make arguments

--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -12,7 +12,7 @@ resource "null_resource" "dynamodb_checker" {
 
 module "dynamodb" {
   source  = "cloudposse/dynamodb/aws"
-  version = "0.10.0"
+  version = "0.20.0"
 
   namespace      = ""
   stage          = ""

--- a/dynamodb_2.tf
+++ b/dynamodb_2.tf
@@ -13,7 +13,7 @@ resource "null_resource" "dynamodb2_checker" {
 
 module "dynamodb2" {
   source  = "cloudposse/dynamodb/aws"
-  version = "0.10.0"
+  version = "0.20.0"
 
   namespace      = ""
   stage          = ""

--- a/dynamodb_3.tf
+++ b/dynamodb_3.tf
@@ -13,7 +13,7 @@ resource "null_resource" "dynamodb3_checker" {
 
 module "dynamodb3" {
   source  = "cloudposse/dynamodb/aws"
-  version = "0.10.0"
+  version = "0.20.0"
 
   namespace      = ""
   stage          = ""

--- a/examples/dynamodb/provider.tf
+++ b/examples/dynamodb/provider.tf
@@ -1,4 +1,4 @@
 provider "aws" {
-  version = "~> 2.37.0"
+  version = "~> 3.0.0"
   region  = "eu-central-1"
 }

--- a/examples/iam/provider.tf
+++ b/examples/iam/provider.tf
@@ -1,4 +1,4 @@
 provider "aws" {
-  version = "~> 2.37.0"
+  version = "~> 3.0.0"
   region  = "eu-central-1"
 }

--- a/examples/rds/provider.tf
+++ b/examples/rds/provider.tf
@@ -1,4 +1,4 @@
 provider "aws" {
-  version = "~> 2.37.0"
+  version = "~> 3.0.0"
   region  = "eu-central-1"
 }

--- a/examples/redis/provider.tf
+++ b/examples/redis/provider.tf
@@ -1,4 +1,4 @@
 provider "aws" {
-  version = "~> 2.37.0"
+  version = "~> 3.0.0"
   region  = "eu-central-1"
 }

--- a/examples/s3/provider.tf
+++ b/examples/s3/provider.tf
@@ -1,4 +1,4 @@
 provider "aws" {
-  version = "~> 2.37.0"
+  version = "~> 3.0.0"
   region  = "eu-central-1"
 }

--- a/rds.tf
+++ b/rds.tf
@@ -19,7 +19,7 @@ locals {
 
 module "rds_sg" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "3.4.0"
+  version = "3.14.0"
 
   create = var.rds_enabled
 
@@ -45,7 +45,7 @@ resource "random_string" "password" {
 # -------------------------------------------------------------------------------------------------
 module "rds" {
   source  = "terraform-aws-modules/rds/aws"
-  version = "2.14.0"
+  version = "2.18.0"
 
   create_db_instance        = var.rds_enabled
   create_db_option_group    = var.rds_enabled


### PR DESCRIPTION
Bump modules versions to be compatible with aws provider 3.X.X also updated examples, changed makefile to use terraform verision 0.12.29 as ver was using light and light uses latest release available in this case 0.13.x
[terraform-aws-rds](https://github.com/terraform-aws-modules/terraform-aws-rds/compare/v2.17.0...v2.18.0)
[cloudposse dynamodb](https://github.com/cloudposse/terraform-aws-dynamodb/releases/tag/0.20.0)