### PR TITLE
Fixes conditional for attaching additional SGs to the RDS

### DIFF
--- a/vpc_and_subnets.tf
+++ b/vpc_and_subnets.tf
@@ -21,7 +21,7 @@ data "aws_subnet_ids" "rds" {
 }
 
 data "aws_security_groups" "for_rds" {
-  count = var.rds_enabled ? 1 : 0
+  count = var.rds_enabled && length(var.additional_sg_names_for_rds) >= 1 ? 1 : 0
   dynamic "filter" {
     for_each = var.additional_sg_names_for_rds
     content {


### PR DESCRIPTION
W/o this fix, all the SGs in that particular VPC would be attached to the RDS instance, if the list would be kept empty.