### PR TITLE
OPS-0 Changes for dynamodb conditionals and rds option/parameter groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ The following resources _CAN_ be created:
 | rds\_node\_type | VM type which should be taken for nodes in the RDS instance | string | `"db.t3.micro"` | no |
 | rds\_option\_group\_name | Option groups for database | string | `"default"` | no |
 | rds\_options | A list of RDS Options to apply | any | `[]` | no |
-| rds\_parameter\_group\_name | Parameter group for database | string | `"default"` | no |
+| rds\_parameter\_group\_name | Parameter group for database | string | `""` | no |
 | rds\_parameters | List of RDS parameters to apply | list(map(string)) | `[]` | no |
 | rds\_port | TCP port where DB accept connections | string | `"3306"` | no |
 | rds\_s3\_dump\_allowed\_ips | List of CIDRs allowed to access data on the S3 bucket for RDS DB dumps | list(string) | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -333,9 +333,9 @@ The following resources _CAN_ be created:
 | rds\_max\_allocated\_storage | Specifies the value for Storage Autoscaling | number | `"0"` | no |
 | rds\_multi\_az | Replication settings | string | `"true"` | no |
 | rds\_node\_type | VM type which should be taken for nodes in the RDS instance | string | `"db.t3.micro"` | no |
-| rds\_option\_group\_name | Option groups for database | string | `""` | no |
+| rds\_option\_group\_name | Option groups for database | string | `"default"` | no |
 | rds\_options | A list of RDS Options to apply | any | `[]` | no |
-| rds\_parameter\_group\_name | Parameter group for database | string | `""` | no |
+| rds\_parameter\_group\_name | Parameter group for database | string | `"default"` | no |
 | rds\_parameters | List of RDS parameters to apply | list(map(string)) | `[]` | no |
 | rds\_port | TCP port where DB accept connections | string | `"3306"` | no |
 | rds\_s3\_dump\_allowed\_ips | List of CIDRs allowed to access data on the S3 bucket for RDS DB dumps | list(string) | `[]` | no |

--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -21,7 +21,7 @@ module "dynamodb" {
   hash_key_type  = var.dynamodb_hash_key_type
   range_key      = var.dynamodb_range_key
   range_key_type = var.dynamodb_range_key_type
-  enabled        = var.dynamodb_enabled ? "true" : "false"
+  enabled        = var.dynamodb_enabled
 
   dynamodb_attributes        = var.dynamodb_attributes
   global_secondary_index_map = var.dynamodb_global_secondary_index_map
@@ -33,7 +33,7 @@ module "dynamodb" {
   autoscale_max_read_capacity  = var.dynamodb_autoscale_max_read_capacity
   autoscale_min_write_capacity = var.dynamodb_autoscale_min_write_capacity
   autoscale_max_write_capacity = var.dynamodb_autoscale_max_write_capacity
-  enable_autoscaler            = var.dynamodb_enable_autoscaler ? "true" : "false"
+  enable_autoscaler            = var.dynamodb_enable_autoscaler
 
   tags = local.tags
 }

--- a/dynamodb_2.tf
+++ b/dynamodb_2.tf
@@ -22,7 +22,7 @@ module "dynamodb2" {
   hash_key_type  = var.dynamodb2_hash_key_type
   range_key      = var.dynamodb2_range_key
   range_key_type = var.dynamodb2_range_key_type
-  enabled        = var.dynamodb2_enabled ? "true" : "false"
+  enabled        = var.dynamodb2_enabled
 
   dynamodb_attributes        = var.dynamodb2_attributes
   global_secondary_index_map = var.dynamodb2_global_secondary_index_map
@@ -35,7 +35,7 @@ module "dynamodb2" {
   autoscale_max_read_capacity  = var.dynamodb2_autoscale_max_read_capacity
   autoscale_min_write_capacity = var.dynamodb2_autoscale_min_write_capacity
   autoscale_max_write_capacity = var.dynamodb2_autoscale_max_write_capacity
-  enable_autoscaler            = var.dynamodb2_enable_autoscaler ? "true" : "false"
+  enable_autoscaler            = var.dynamodb2_enable_autoscaler
 
   tags = local.tags
 }

--- a/dynamodb_3.tf
+++ b/dynamodb_3.tf
@@ -22,7 +22,7 @@ module "dynamodb3" {
   hash_key_type  = var.dynamodb3_hash_key_type
   range_key      = var.dynamodb3_range_key
   range_key_type = var.dynamodb3_range_key_type
-  enabled        = var.dynamodb3_enabled ? "true" : "false"
+  enabled        = var.dynamodb3_enabled
 
   dynamodb_attributes        = var.dynamodb3_attributes
   global_secondary_index_map = var.dynamodb3_global_secondary_index_map
@@ -35,7 +35,7 @@ module "dynamodb3" {
   autoscale_max_read_capacity  = var.dynamodb3_autoscale_max_read_capacity
   autoscale_min_write_capacity = var.dynamodb3_autoscale_min_write_capacity
   autoscale_max_write_capacity = var.dynamodb3_autoscale_max_write_capacity
-  enable_autoscaler            = var.dynamodb3_enable_autoscaler ? "true" : "false"
+  enable_autoscaler            = var.dynamodb3_enable_autoscaler
 
   tags = local.tags
 }

--- a/rds.tf
+++ b/rds.tf
@@ -52,8 +52,8 @@ module "rds" {
   create_db_parameter_group = var.rds_enabled
   create_db_subnet_group    = var.rds_enabled
 
-  option_group_name    = var.rds_option_group_name != "default" ? var.rds_option_group_name : "${var.rds_option_group_name}:${var.rds_family}"
-  parameter_group_name = var.rds_parameter_group_name != "default" ? var.rds_parameter_group_name : "${var.rds_parameter_group_name}:${var.rds_family}"
+  option_group_name    = var.rds_option_group_name == "default" ? "${var.rds_option_group_name}:${var.rds_family}" : var.rds_option_group_name
+  parameter_group_name = var.rds_parameter_group_name == "default" ? "${var.rds_parameter_group_name}:${var.rds_family}" : var.rds_parameter_group_name
   db_subnet_group_name = var.rds_db_subnet_group_name
   ca_cert_identifier   = var.rds_ca_cert_identifier
 

--- a/rds.tf
+++ b/rds.tf
@@ -52,8 +52,8 @@ module "rds" {
   create_db_parameter_group = var.rds_enabled
   create_db_subnet_group    = var.rds_enabled
 
-  option_group_name    = var.rds_option_group_name
-  parameter_group_name = var.rds_parameter_group_name
+  option_group_name    = var.rds_option_group_name != "default" ? var.rds_option_group_name : "${var.rds_option_group_name}:${var.rds_family}"
+  parameter_group_name = var.rds_parameter_group_name != "default" ? var.rds_parameter_group_name : "${var.rds_parameter_group_name}:${var.rds_family}"
   db_subnet_group_name = var.rds_db_subnet_group_name
   ca_cert_identifier   = var.rds_ca_cert_identifier
 

--- a/rds.tf
+++ b/rds.tf
@@ -53,7 +53,7 @@ module "rds" {
   create_db_subnet_group    = var.rds_enabled
 
   option_group_name    = (
-    var.rds_option_group_name == "default" && module.rds.module.db_option_group.this_db_option_group_id != "" ?
+    var.rds_option_group_name == "default" && module.rds.this_db_option_group_id != "" ?
     module.rds.module.db_option_group.this_db_option_group_id : (
       var.rds_option_group_name == "default" ? "${var.rds_option_group_name}:${var.rds_family}" : var.rds_option_group_name
     )

--- a/rds.tf
+++ b/rds.tf
@@ -52,7 +52,12 @@ module "rds" {
   create_db_parameter_group = var.rds_enabled
   create_db_subnet_group    = var.rds_enabled
 
-  option_group_name    = var.rds_option_group_name == "default" ? "${var.rds_option_group_name}:${var.rds_family}" : var.rds_option_group_name
+  option_group_name    = (
+    var.rds_option_group_name == "default" && module.rds.module.db_option_group.this_db_option_group_id != "" ?
+    module.rds.module.db_option_group.this_db_option_group_id : (
+      var.rds_option_group_name == "default" ? "${var.rds_option_group_name}:${var.rds_family}" : var.rds_option_group_name
+    )
+  )
   parameter_group_name = var.rds_parameter_group_name == "default" ? "${var.rds_parameter_group_name}:${var.rds_family}" : var.rds_parameter_group_name
   db_subnet_group_name = var.rds_db_subnet_group_name
   ca_cert_identifier   = var.rds_ca_cert_identifier

--- a/rds.tf
+++ b/rds.tf
@@ -1,12 +1,6 @@
 locals {
   rds_identifier = length(var.rds_identifier_override) > 0 ? var.rds_identifier_override : var.name
   rds_db_name    = length(regexall("sqlserver-.*", var.rds_engine)) > 0 ? null : (length(var.rds_dbname_override) > 0 ? var.rds_dbname_override : local.rds_identifier)
-  rds_opt_name   = (
-    var.rds_option_group_name == "default" && module.rds.this_db_option_group_id != "" ?
-    module.rds.this_db_option_group_id : (
-      var.rds_option_group_name == "default" ? "${var.rds_option_group_name}:${var.rds_family}" : var.rds_option_group_name
-    )
-  )
   password       = var.rds_use_random_password ? join("", random_string.password.*.result) : var.rds_admin_pass
 }
 
@@ -58,8 +52,8 @@ module "rds" {
   create_db_parameter_group = var.rds_enabled
   create_db_subnet_group    = var.rds_enabled
 
-  option_group_name    = local.rds_opt_name
-  parameter_group_name = var.rds_parameter_group_name == "default" ? "${var.rds_parameter_group_name}:${var.rds_family}" : var.rds_parameter_group_name
+  option_group_name    = var.rds_option_group_name != "default" ? var.rds_option_group_name : "${var.rds_option_group_name}:${var.rds_family}"
+  parameter_group_name = var.rds_parameter_group_name
   db_subnet_group_name = var.rds_db_subnet_group_name
   ca_cert_identifier   = var.rds_ca_cert_identifier
 

--- a/variables.tf
+++ b/variables.tf
@@ -652,7 +652,7 @@ variable "rds_iam_database_authentication_enabled" {
 variable "rds_parameter_group_name" {
   description = "Parameter group for database"
   type        = string
-  default     = "default"
+  default     = ""
 }
 
 variable "rds_parameters" {

--- a/variables.tf
+++ b/variables.tf
@@ -652,7 +652,7 @@ variable "rds_iam_database_authentication_enabled" {
 variable "rds_parameter_group_name" {
   description = "Parameter group for database"
   type        = string
-  default     = ""
+  default     = "default"
 }
 
 variable "rds_parameters" {
@@ -664,7 +664,7 @@ variable "rds_parameters" {
 variable "rds_option_group_name" {
   description = "Option groups for database"
   type        = string
-  default     = ""
+  default     = "default"
 }
 
 variable "rds_options" {


### PR DESCRIPTION
The following 
- dynamodb_enabled
-dynamodb_enable_autoscaler

Are already boolean variables, it doesn't need the conditional expression, this variables are initialised as false by default.

There is a [commit](https://github.com/terraform-aws-modules/terraform-aws-rds/commit/bdc2de20ced43490d02f61be4c704eae282785fb) in the module for rds that has not been yet merged into master this will avoid the problem of the creation by default of the option groups and parameter groups.
To avoid this the variables:
- rds_option_group_name
- rds_parameter_group_name

Were set to the value `default` instead of an empty string