### PR TITLE
Allows setting RDS options

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ The following resources _CAN_ be created:
 | rds\_max\_allocated\_storage | Specifies the value for Storage Autoscaling | number | `"0"` | no |
 | rds\_multi\_az | Replication settings | string | `"true"` | no |
 | rds\_node\_type | VM type which should be taken for nodes in the RDS instance | string | `"db.t3.micro"` | no |
-| rds\_option\_group\_name | Option groups for database | string | `"default"` | no |
+| rds\_option\_group\_name | Option groups for database | string | `""` | no |
 | rds\_options | A list of RDS Options to apply | any | `[]` | no |
 | rds\_parameter\_group\_name | Parameter group for database | string | `""` | no |
 | rds\_parameters | List of RDS parameters to apply | list(map(string)) | `[]` | no |

--- a/rds.tf
+++ b/rds.tf
@@ -55,7 +55,7 @@ module "rds" {
   create_db_parameter_group = var.rds_enabled
   create_db_subnet_group    = var.rds_enabled
 
-  option_group_name    = var.rds_option_group_name != "default" ? var.rds_option_group_name : "${var.rds_option_group_name}:${var.rds_family}"
+  option_group_name    = var.rds_option_group_name
   parameter_group_name = var.rds_parameter_group_name
   db_subnet_group_name = var.rds_db_subnet_group_name
   ca_cert_identifier   = var.rds_ca_cert_identifier

--- a/variables.tf
+++ b/variables.tf
@@ -675,7 +675,7 @@ variable "rds_parameters" {
 variable "rds_option_group_name" {
   description = "Option groups for database"
   type        = string
-  default     = "default"
+  default     = ""
 }
 
 variable "rds_options" {


### PR DESCRIPTION
This partially reverts this commit: https://github.com/Flaconi/terraform-aws-microservice/pull/41/commits/22d3cd70a5b0e450538a4fa56e9c4055b0a832d8

Without this, we can't set options for the RDS option groups.

Upcoming release tag: `v2.10.0`