### PR TITLE
Allows handling the encrypted database dump files

### DIFF
--- a/rds.tf
+++ b/rds.tf
@@ -240,6 +240,19 @@ data "aws_iam_policy_document" "rds_dumps_role" {
       "${aws_s3_bucket.rds_dumps[0].arn}/*",
     ]
   }
+
+  statement {
+    sid = "AllowDumpS3BucketObjectEncryption"
+
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Encrypt",
+      "kms:DescribeKey",
+      "kms:Decrypt",
+    ]
+
+    resources = [aws_kms_key.this[0].arn]
+  }
 }
 
 # Trust policy for RDS role


### PR DESCRIPTION
This is needed, so that the RDS instance can store its dump files but can also read them back, while the S3 objects are encrypted with KMS.

Upcoming release tag: `v2.10.1`