### PR TITLE
Allows RDS IOPS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ The following resources _CAN_ be created:
 | rds\_final\_snapshot\_identifier\_override | RDS final snapshot identifier override. | string | `""` | no |
 | rds\_iam\_database\_authentication\_enabled | Enable / disable IAM database authentication | string | `"false"` | no |
 | rds\_identifier\_override | RDS identifier override. Use only lowercase, numbers and -, _., only use when it needs to be different from var.name | string | `""` | no |
+| rds\_iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | number | `"0"` | no |
 | rds\_kms\_key\_id | KMS key ARN for storage encryption | string | `""` | no |
 | rds\_license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `""` | no |
 | rds\_maintenance\_window | Window of RDS Maintenance | string | `"Mon:16:00-Mon:18:00"` | no |

--- a/rds.tf
+++ b/rds.tf
@@ -6,6 +6,7 @@ locals {
   enhanced_monitoring_interval    = contains([1, 5, 10, 15, 30, 60], var.rds_enhanced_monitoring_interval) ? var.rds_enhanced_monitoring_interval : 0
   create_enhanced_monitoring_role = local.enhanced_monitoring_interval > 0 ? true : false
   enhanced_monitoring_role_name   = local.enhanced_monitoring_interval > 0 ? "${var.env}-${local.rds_identifier}-monitoring" : null
+  rds_storage_type                = var.rds_iops > 0 ? "io1" : var.rds_storage_type
 }
 
 # -------------------------------------------------------------------------------------------------
@@ -71,6 +72,8 @@ module "rds" {
   engine_version        = var.rds_engine_version
   major_engine_version  = var.rds_major_engine_version
   instance_class        = var.rds_node_type
+  storage_type          = local.rds_storage_type
+  iops                  = var.rds_iops
   allocated_storage     = var.rds_allocated_storage
   max_allocated_storage = var.rds_max_allocated_storage
   family                = var.rds_family

--- a/variables.tf
+++ b/variables.tf
@@ -632,6 +632,12 @@ variable "rds_max_allocated_storage" {
   default     = 0
 }
 
+variable "rds_iops" {
+  description = "The amount of provisioned IOPS. Setting this implies a storage_type of 'io1'"
+  type        = number
+  default     = 0
+}
+
 # -------------------------------------------------------------------------------------------------
 # RDS instance admin user & pass
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Allows the user to specify IOPS settings of an RDS instance. If it is set, the storage type will be set to `io1` automatically.