### PR TITLE
Allows users to specify RDS operations timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ The following resources _CAN_ be created:
 | rds\_storage\_encrypted | Enable encryption for RDS instance storage | string | `"true"` | no |
 | rds\_storage\_type | Storage type | string | `"gp2"` | no |
 | rds\_subnet\_tag\_filter | The Map to filter the subnets of the VPC where the RDS component of the Microservice resides | map | `{}` | no |
+| rds\_timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map(string) | `{ "create": "40m", "delete": "40m", "update": "80m" }` | no |
 | rds\_use\_random\_password | with rds_use_random_password set to true the RDS database will be configured with a random password | string | `"true"` | no |
 | redis\_allowed\_subnet\_cidrs | List of CIDRs/subnets which should be able to connect to the Redis cluster | list(string) | `[ "127.0.0.1/32" ]` | no |
 | redis\_apply\_immediately | Specifies whether any modifications are applied immediately, or during the next maintenance window. | string | `"false"` | no |

--- a/rds.tf
+++ b/rds.tf
@@ -117,6 +117,8 @@ module "rds" {
 
   parameters = var.rds_parameters
   options    = var.rds_options
+
+  timeouts = var.rds_timeouts
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -564,6 +564,16 @@ variable "rds_allowed_subnet_cidrs" {
   default     = ["127.0.0.1/32"]
 }
 
+variable "rds_timeouts" {
+  description = "(Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times"
+  type        = map(string)
+  default = {
+    create = "40m"
+    update = "80m"
+    delete = "40m"
+  }
+}
+
 # -------------------------------------------------------------------------------------------------
 # RDS instance engine
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
For handling long-running operations.
Upcoming release: `v3.0.4`