### PR TITLE
OPS-0 Add variable to enable multi-az for elasticache replication group

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ The following resources _CAN_ be created:
 | redis\_group\_parameter\_group\_name | Redis parameter group name | string | `"default.redis5.0.cluster.on"` | no |
 | redis\_instance\_type | Redis instance type | string | `"cache.m4.large"` | no |
 | redis\_maintenance\_window | Redis snapshot window | string | `"mon:10:00-mon:12:00"` | no |
+| redis\_multi\_az\_enabled | Specifies whether to enable Multi-AZ Support for the replication group. If true, automatic_failover_enabled must also be enabled. | bool | `"false"` | no |
 | redis\_port | Redis port | string | `"6379"` | no |
 | redis\_replicas\_count | Number of replica nodes in each node group | string | `"1"` | no |
 | redis\_shards\_count | Number of shards | string | `"1"` | no |

--- a/redis.tf
+++ b/redis.tf
@@ -53,6 +53,7 @@ resource "aws_elasticache_replication_group" "this" {
   parameter_group_name = var.redis_group_parameter_group_name
 
   automatic_failover_enabled = true
+  multi_az_enabled           = var.redis_multi_az_enabled
 
   cluster_mode {
     # Number of shards

--- a/variables.tf
+++ b/variables.tf
@@ -515,6 +515,12 @@ variable "redis_apply_immediately" {
   default     = false
 }
 
+variable "redis_multi_az_enabled" {
+  description = "Specifies whether to enable Multi-AZ Support for the replication group. If true, automatic_failover_enabled must also be enabled."
+  type        = bool
+  default     = false
+}
+
 # -------------------------------------------------------------------------------------------------
 # RDS
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
In order to unblock `terragrunt/envs/aws/prod/eu-central-1/microservices/ui-shop-gateway` on 
https://github.com/Flaconi/ops-infra-maze/pull/716#issuecomment-912364306
So I have to add a variable to enable multi-az in elasticache resource

---
Default value is false in dev and testing env. 
Ture in prod env