### PR TITLE
Allows RDS DB dumps stored in S3 buckets to be accessible cross-account

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ The following resources _CAN_ be created:
 | rds\_port | TCP port where DB accept connections | string | `"3306"` | no |
 | rds\_s3\_dump\_allowed\_ips | List of CIDRs allowed to access data on the S3 bucket for RDS DB dumps | list(string) | `[]` | no |
 | rds\_s3\_dump\_name\_prefix | The S3 name prefix | string | `""` | no |
+| rds\_s3\_kms\_dump\_key\_additional\_role\_arns | List of IAM role ARNs that are able to access the KMS key used for encrypting RDS dump files in the S3 bucket | list(string) | `[]` | no |
 | rds\_skip\_final\_snapshot | Skip final snapshot on deletion | string | `"false"` | no |
 | rds\_storage\_encrypted | Enable encryption for RDS instance storage | string | `"true"` | no |
 | rds\_storage\_type | Storage type | string | `"gp2"` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 # -------------------------------------------------------------------------------------------------
 # IAM Policy Document
 # -------------------------------------------------------------------------------------------------
@@ -304,6 +306,23 @@ resource "aws_iam_user_policy" "kms" {
   policy = element(concat(data.aws_iam_policy_document.kms_permissions.*.json, [""]), 0)
 }
 
+data "aws_iam_policy_document" "kms_key" {
+  count = local.kms_enabled ? 1 : 0
+
+  statement {
+    actions = [
+      "kms:*",
+    ]
+    resources = ["*"]
+    principals {
+      type = "AWS"
+      identifiers = concat(
+        ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"],
+        var.rds_s3_kms_dump_key_additional_role_arns,
+      )
+    }
+  }
+}
 
 ##
 ## IAM S3 permissions

--- a/kms.tf
+++ b/kms.tf
@@ -6,6 +6,7 @@ locals {
 resource "aws_kms_key" "this" {
   count       = local.kms_enabled ? 1 : 0
   description = "KMS key for encrypting - ${var.env} - ${var.name}"
+  policy      = element(concat(data.aws_iam_policy_document.kms_key[*].json, []), 0)
 
   tags = local.tags
 }

--- a/rds.tf
+++ b/rds.tf
@@ -161,7 +161,7 @@ resource "aws_s3_bucket" "rds_dumps" {
   }
 }
 
-# Buckup S3 bucket policy
+# Backup S3 bucket policy
 data "aws_iam_policy_document" "rds_dumps" {
   count = local.rds_dumps_enabled ? 1 : 0
 
@@ -170,6 +170,8 @@ data "aws_iam_policy_document" "rds_dumps" {
     actions = [
       "s3:PutObject",
       "s3:GetObject",
+      "s3:ListMultipartUploadParts",
+      "s3:AbortMultipartUpload",
       "s3:ListBucket",
     ]
     resources = [
@@ -178,8 +180,11 @@ data "aws_iam_policy_document" "rds_dumps" {
     ]
 
     principals {
-      identifiers = [aws_iam_role.rds_dumps[0].arn]
-      type        = "AWS"
+      identifiers = concat(
+        [aws_iam_role.rds_dumps[0].arn],
+        var.rds_s3_kms_dump_key_additional_role_arns,
+      )
+      type = "AWS"
     }
   }
 

--- a/rds.tf
+++ b/rds.tf
@@ -168,11 +168,12 @@ data "aws_iam_policy_document" "rds_dumps" {
   statement {
     sid = "AllowReadWriteAccessWithRDSIAMRole"
     actions = [
-      "s3:PutObject",
-      "s3:GetObject",
-      "s3:ListMultipartUploadParts",
       "s3:AbortMultipartUpload",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
       "s3:ListBucket",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
     ]
     resources = [
       aws_s3_bucket.rds_dumps[0].arn,

--- a/variables.tf
+++ b/variables.tf
@@ -554,6 +554,12 @@ variable "rds_s3_dump_allowed_ips" {
   default     = []
 }
 
+variable "rds_s3_kms_dump_key_additional_role_arns" {
+  description = "List of IAM role ARNs that are able to access the KMS key used for encrypting RDS dump files in the S3 bucket"
+  type        = list(string)
+  default     = []
+}
+
 variable "rds_identifier_override" {
   description = "RDS identifier override. Use only lowercase, numbers and -, _., only use when it needs to be different from var.name"
   default     = ""


### PR DESCRIPTION
Self-explanatory.

Upcoming release: `v3.1.0`
