### PR TITLE
OPS-0 Fix aws_iam_role.rds_dump is empty list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 #  Local .terraform directories
 **/.terraform/*
+**/.terraform.lock.hcl
 
 # .tfstate files
 *.tfstate

--- a/rds-s3-dumps.tf
+++ b/rds-s3-dumps.tf
@@ -3,7 +3,7 @@ locals {
   rds_dumps_enabled = var.rds_enabled && var.rds_enable_s3_dump
 
   rds_s3_bucket_policy_principal_identifiers = concat(
-    var.rds_s3_dump_role_arn == "" ? flatten(concat(
+    var.rds_s3_dump_role_arn == "" && local.rds_dumps_enabled ? flatten(concat(
       [aws_iam_role.rds_dumps[0].arn],
       var.rds_s3_kms_dump_key_additional_role_arns
       )) : flatten(concat(


### PR DESCRIPTION
Fix the following error when `terraform plan` in `examples/dynamodb/`
Coming release is v3.3.1
```
│ Error: Invalid index
│ 
│   on ../../rds-s3-dumps.tf line 7, in locals:
│    7:       [aws_iam_role.rds_dumps[0].arn],
│     ├────────────────
│     │ aws_iam_role.rds_dumps is empty tuple
│ 
│ The given key does not identify an element in this collection value: the collection has no elements.
```