### PR TITLE
Allow-Multiple-Storage-Types-With-Provisioned-IOPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1495,7 +1495,7 @@ Description: Storage type
 
 Type: `string`
 
-Default: `"gp2"`
+Default: `"gp3"`
 
 ### <a name="input_rds_allocated_storage"></a> [rds\_allocated\_storage](#input\_rds\_allocated\_storage)
 

--- a/rds.tf
+++ b/rds.tf
@@ -6,7 +6,6 @@ locals {
   enhanced_monitoring_interval    = contains([1, 5, 10, 15, 30, 60], var.rds_enhanced_monitoring_interval) ? var.rds_enhanced_monitoring_interval : 0
   create_enhanced_monitoring_role = local.enhanced_monitoring_interval > 0 ? true : false
   enhanced_monitoring_role_name   = local.enhanced_monitoring_interval > 0 ? "${var.env}-${local.rds_identifier}-monitoring" : null
-  rds_storage_type                = var.rds_iops > 0 ? "io1" : var.rds_storage_type
 }
 
 # -------------------------------------------------------------------------------------------------
@@ -78,7 +77,7 @@ module "rds" {
   engine_version        = var.rds_engine_version
   major_engine_version  = var.rds_major_engine_version
   instance_class        = var.rds_node_type
-  storage_type          = local.rds_storage_type
+  storage_type          = var.rds_storage_type
   iops                  = var.rds_iops
   allocated_storage     = var.rds_allocated_storage
   max_allocated_storage = var.rds_max_allocated_storage

--- a/variables.tf
+++ b/variables.tf
@@ -947,7 +947,7 @@ variable "rds_multi_az" {
 variable "rds_storage_type" {
   description = "Storage type"
   type        = string
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "rds_allocated_storage" {


### PR DESCRIPTION
Since AWS RDS supports new storage types, namely io2 and gp3 that both support provisioned IOPS, it makes sense to remove the opinionated approach once taken and to allow free choice of storage type instead of forcing to io1. Also, changing default to gp3 to use the latest and greatest general purpose storage type by default.